### PR TITLE
Fixed default parameter values

### DIFF
--- a/bwperimtrace.m
+++ b/bwperimtrace.m
@@ -13,10 +13,10 @@ function cellout = bwperimtrace(in,xlims,ylims)
 % University of Oxford
 
 if ~exist('xlims','var')
-    xlims = 1:size(in,1);
+    xlims = [1 size(in,2)];
 end
 if ~exist('ylims','var')
-    ylims = 1:size(in,2);
+    ylims = [1 size(in,1)];
 end
 
 if all(~in)


### PR DESCRIPTION
The functions fails if not called with all three parameters. This seems to be because
a) instead of 2 limit values, the range of values between the limits is used and
b) Dimensions are swapped (since the matrix is transposed later)

This pull request should fix it.